### PR TITLE
Disable async stack capturing while profiling

### DIFF
--- a/lib/profiler.js
+++ b/lib/profiler.js
@@ -1,6 +1,9 @@
 const { Cc, Ci, Cu } = require("chrome");
 const system = require('sdk/system');
+const fxprefs = require("sdk/preferences/service");
 Cu.import("resource://gre/modules/Services.jsm");
+const kAsyncStackPrefName = "javascript.options.asyncstack";
+let gAsyncStacksWereEnabled = false;
 
 function getArch() {
   let abi = Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULRuntime).XPCOMABI;
@@ -19,6 +22,8 @@ function profiler() {
 
 function startProfiler(entries, interval, features, threads) {
   return new Promise((resolve, reject) => {
+    gAsyncStacksWereEnabled = fxprefs.get(kAsyncStackPrefName, false);
+    fxprefs.set(kAsyncStackPrefName, false);
     if (threads.length) {
       try {
         profiler().StartProfiler(entries, interval, features, features.length, threads, threads.length);
@@ -34,6 +39,7 @@ function startProfiler(entries, interval, features, threads) {
 
 function stopProfiler() {
   return new Promise((resolve, reject) => {
+    fxprefs.set(kAsyncStackPrefName, gAsyncStacksWereEnabled);
     profiler().StopProfiler();
     resolve();
   });


### PR DESCRIPTION
Async stack capturing can be super expensive, and given that it is
disabled on Firefox release channel due to its performance cost,
it's better to disable it in order to avoid skewing the profiles.