### PR TITLE
Better panel sizing

### DIFF
--- a/data/panel.js
+++ b/data/panel.js
@@ -31,6 +31,9 @@ function renderState(state) {
   }
   const information = calculateInformation(state);
   document.querySelector('.relevancy-level-fill').style.width = `${information * 100}%`;
+
+  const height = document.body.getBoundingClientRect().height;
+  self.port.emit('ProfilerControlEvent', { type: 'PanelHeightUpdated', height });
 }
 
 function renderControls(state) {
@@ -97,8 +100,6 @@ document.querySelector('#button-capture').addEventListener('click', () => {
 document.querySelector('#settings-label').addEventListener('click', () => {
   gState = Object.assign({}, gState, { settingsOpen: !gState.settingsOpen });
   renderState(gState);
-  const height = document.body.getBoundingClientRect().height;
-  self.port.emit('ProfilerControlEvent', { type: 'PanelHeightUpdated', height });
 });
 
 document.querySelector('.interval-range').addEventListener('input', e => {

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ function setPrefs() {
 }
 
 function startProfiler() {
+  readPrefs();
   const threads = settings.threads.split(",");
   const enabledFeatures = Object.keys(settings.features).filter(f => settings.features[f]);
   enabledFeatures.push("leaf");
@@ -102,6 +103,7 @@ const button = ToggleButton({
   onChange: (state) => {
     if (state.checked) {
       readPrefs();
+      panel.port.emit('ProfilerStateUpdated', settings);
       panel.port.emit('ProfilerStateUpdated', { settingsOpen: false });
       panel.resize(panel.width, 168 + 2);
       panel.show({ position: button });


### PR DESCRIPTION
This will make the panel big enough to show the Settings button on Windows and Linux. The default height was too low on non-Mac platforms and the height wasn't updated until the settings button was clicked.

This pull request also includes the other changeset because I don't know how to use github. I suppose I should have based this changeset on the upstream base.