### PR TITLE
Improve controls alignment in the settings panel

### DIFF
--- a/data/panel.html
+++ b/data/panel.html
@@ -196,7 +196,7 @@ kbd {
   background: #F7F7F7;
 }
 
-.settings:not(.open) > .settings-list,
+.settings:not(.open) > .settings-content,
 .settings:not(.open) > .settings-apply-button-wrapper {
   display: none;
 }
@@ -273,15 +273,10 @@ kbd {
   background-size: 400px 20px;
 }
 
-.settings-list {
-  margin: 0;
-  padding: 0;
-  line-height: 22px;
-}
-
-.settings-list > li {
+.settings-content {
   margin: 0;
   padding: 0 10px;
+  line-height: 22px;
   display: grid;
   grid-template-columns: 7em auto;
   grid-template-rows: auto;
@@ -300,6 +295,7 @@ kbd {
 
 .range-input {
   margin: 0;
+  width: 0;
   flex: 1;
 }
 
@@ -308,6 +304,10 @@ kbd {
   width: 4em;
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.settings-textbox {
+  min-width: 0;
 }
 
 .features-list {
@@ -386,37 +386,29 @@ kbd {
   </dd>
 </dl>
 
-<div class="settings">
+<section class="settings">
   <h1 id="settings-label">Settings</h1>
-  <ul class="settings-list">
-    <li>
-      <h1 class="settings-setting-label">Interval:</h1>
-      <span class="range-with-value">
-        <input type="range" class="range-input interval-range" min="0" max="100">
-        <span class="range-value interval-value">1 ms</span>
-      </span>
-    </li>
-    <li>
-      <h1 class="settings-setting-label">Buffer size:</h1>
-      <span class="range-with-value">
-        <input type="range" class="range-input buffersize-range" min="0" max="100">
-        <span class="range-value buffersize-value">9 MB</span>
-      </span>
-    </li>
-    <li>
-      <h1 class="settings-setting-label">Threads:</h1>
-      <input type="text" class="settings-textbox threads-textbox"
-             title="Comma-separated list of case-insensitive substring filters for the thread name"
-             value="GeckoMain,Compositor">
-    </li>
-    <li>
-      <h1 class="settings-setting-label">Features:</h1>
-      <ul class="features-list">
-        <li><label><input type="checkbox" class="stackwalk-checkbox" checked>Stack walk</label></li>
-        <li><label><input type="checkbox" class="js-checkbox" checked>JavaScript</label></li>
-        <li><label><input type="checkbox" class="tasktracer-checkbox">Task tracer</label></li>
-      </ul>
-    </li>
-  </ul>
+  <section class="settings-content">
+    <h1 class="settings-setting-label">Interval:</h1>
+    <span class="range-with-value">
+      <input type="range" class="range-input interval-range" min="0" max="100">
+      <span class="range-value interval-value">1 ms</span>
+    </span>
+    <h1 class="settings-setting-label">Buffer size:</h1>
+    <span class="range-with-value">
+      <input type="range" class="range-input buffersize-range" min="0" max="100">
+      <span class="range-value buffersize-value">9 MB</span>
+    </span>
+    <h1 class="settings-setting-label">Threads:</h1>
+    <input type="text" class="settings-textbox threads-textbox"
+           title="Comma-separated list of case-insensitive substring filters for the thread name"
+           value="GeckoMain,Compositor">
+    <h1 class="settings-setting-label">Features:</h1>
+    <ul class="features-list">
+      <li><label><input type="checkbox" class="stackwalk-checkbox" checked>Stack walk</label></li>
+      <li><label><input type="checkbox" class="js-checkbox" checked>JavaScript</label></li>
+      <li><label><input type="checkbox" class="tasktracer-checkbox">Task tracer</label></li>
+    </ul>
+  </section>
   <p class="settings-apply-button-wrapper"><input type="button" class="settings-apply-button" value="Apply (Restart Profiler)"></p>
-</div>
+</section>

--- a/resources/panel-container.html
+++ b/resources/panel-container.html
@@ -21,5 +21,5 @@ iframe {
 <body>
 
 <div id="wrapper">
-  <iframe src="panel-ideas.html" style="width: 280px; height: 172px; border: 0; border-radius: 3.5px; margin: 0; padding: 1px"></iframe>
+  <iframe src="panel-ideas.html" style="width: 330px; height: 330px; border: 0; border-radius: 3.5px; margin: 0; padding: 1px"></iframe>
 </div>

--- a/resources/panel-ideas.html
+++ b/resources/panel-ideas.html
@@ -196,7 +196,7 @@ kbd {
   background: #F7F7F7;
 }
 
-.settings:not(.open) > .settings-list,
+.settings:not(.open) > .settings-content,
 .settings:not(.open) > .settings-apply-button-wrapper {
   display: none;
 }
@@ -273,15 +273,10 @@ kbd {
   background-size: 400px 20px;
 }
 
-.settings-list {
-  margin: 0;
-  padding: 0;
-  line-height: 22px;
-}
-
-.settings-list > li {
+.settings-content {
   margin: 0;
   padding: 0 10px;
+  line-height: 22px;
   display: grid;
   grid-template-columns: 7em auto;
   grid-template-rows: auto;
@@ -300,13 +295,19 @@ kbd {
 
 .range-input {
   margin: 0;
+  width: 0;
   flex: 1;
 }
 
 .range-value {
   margin-left: 10px;
-  width: 3em;
+  width: 4em;
+  white-space: nowrap;
   flex-shrink: 0;
+}
+
+.settings-textbox {
+  min-width: 0;
 }
 
 .features-list {
@@ -385,35 +386,27 @@ kbd {
   </dd>
 </dl>
 
-<div class="settings">
+<section class="settings open">
   <h1 id="settings-label">Settings</h1>
-  <ul class="settings-list">
-    <li>
-      <h1 class="settings-setting-label">Interval:</h1>
-      <span class="range-with-value">
-        <input type="range" class="range-input">
-        <span class="range-value">1 ms</span>
-      </span>
-    </li>
-    <li>
-      <h1 class="settings-setting-label">Buffer size:</h1>
-      <span class="range-with-value">
-        <input type="range" class="range-input">
-        <span class="range-value">9 MB</span>
-      </span>
-    </li>
-    <li>
-      <h1 class="settings-setting-label">Threads:</h1>
-      <input type="text" class="settings-textbox" title="Comma-separated list of case-insensitive substring filters for the thread name" value="GeckoMain,Compositor">
-    </li>
-    <li>
-      <h1 class="settings-setting-label">Features:</h1>
-      <ul class="features-list">
-        <li><label><input type="checkbox" checked>Stack walk</label></li>
-        <li><label><input type="checkbox" checked>JavaScript</label></li>
-        <li><label><input type="checkbox">Task tracer</label></li>
-      </ul>
-    </li>
-  </ul>
+  <section class="settings-content">
+    <h1 class="settings-setting-label">Interval:</h1>
+    <span class="range-with-value">
+      <input type="range" class="range-input">
+      <span class="range-value">1 ms</span>
+    </span>
+    <h1 class="settings-setting-label">Buffer size:</h1>
+    <span class="range-with-value">
+      <input type="range" class="range-input">
+      <span class="range-value">9 MB</span>
+    </span>
+    <h1 class="settings-setting-label">Threads:</h1>
+    <input type="text" class="settings-textbox" title="Comma-separated list of case-insensitive substring filters for the thread name" value="GeckoMain,Compositor">
+    <h1 class="settings-setting-label">Features:</h1>
+    <ul class="features-list">
+      <li><label><input type="checkbox" checked>Stack walk</label></li>
+      <li><label><input type="checkbox" checked>JavaScript</label></li>
+      <li><label><input type="checkbox">Task tracer</label></li>
+    </ul>
+  </section>
   <p class="settings-apply-button-wrapper"><input type="button" class="settings-apply-button" value="Apply (Restart Profiler)"></p>
-</div>
+</section>


### PR DESCRIPTION
This makes the controls squish correctly. Grid elements use min-width:0 to make themselves squishable, nested flexbox elements use width:0. These values have been recommended by dholbert who implemented flexbox in Firefox.