### PR TITLE
Add package.json for build and run commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "title": "Gecko Profiler",
+  "name": "geckoprofiler",
+  "description": "Collect platform profiles from Firefox Desktop.",
+  "author": "Markus Stange <mstange@themasta.com>",
+  "license": "MIT",
+  "devDependencies": {
+    "web-ext": "^1.8.1"
+  },
+  "repository": "https://github.com/devtools-html/Gecko-Profiler-Addon",
+  "scripts": {
+    "start": "web-ext run",
+    "start-mac-nightly": "web-ext run --firefox=/Applications/FirefoxNightly.app",
+    "build": "web-ext build -i README.md package.json *.rdf transition resources"
+  }
+}


### PR DESCRIPTION
Regarding the ignore files in the build command: web-ext-artifacts,
node_modules, anything starting with ".", and anything ending with
".xpi" are already ignored by default.