### PR TITLE
Add preferences for changing the report URL

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,14 +15,6 @@
     "default_title": "Gecko Profiler",
     "default_icon": "icons/toolbar_off.png"
   },
-  "content_scripts": [
-    {
-      "all_frames": false,
-      "js": ["content.js"],
-      "matches": ["https://perf-html.io/*"],
-      "run_at": "document_start"
-    }
-  ],
   "applications": {
     "gecko": {
       "id": "geckoprofiler@mozilla.com",

--- a/options.html
+++ b/options.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <form>
+        <label>Profile viewer URL<input type="text" id="profileViewerURL" ></label>
+        <button type="submit">Save</button>
+    </form>
+    <div id="errors"></div>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,57 @@
+const DEFAULT_OPTIONS = {
+  profileViewerURL: 'https://perf-html.io',
+};
+let currentOptions;
+
+async function saveOptions(e) {
+  e.preventDefault();
+
+  const errorsNode = document.getElementById('errors');
+  errorsNode.innerHTML = '';
+
+  const optionsObj = {};
+  for (let key of Object.keys(DEFAULT_OPTIONS)) {
+    optionsObj[key] = document.getElementById(key).value;
+    switch (key) {
+      case 'profileViewerURL':
+        try {
+          if (optionsObj[key] !== currentOptions[key]) {
+            const granted = await browser.permissions.request({
+              origins: [getPermissionFromProfileViewerURL(optionsObj[key])],
+            });
+            await browser.permissions.remove({
+              origins: [getPermissionFromProfileViewerURL(currentOptions[key])],
+            });
+            if (!granted) {
+              throw new Error('Permission for provided URL not granted.');
+            }
+
+            currentOptions[key] = optionsObj[key];
+          }
+        } catch (e) {
+          optionsObj[key] = currentOptions[key];
+          const errorDiv = document.createElement('div');
+          errorDiv.textContent = 'Failed to set permission: ' + key;
+          errorsNode.appendChild(errorDiv);
+        }
+        break;
+    }
+  }
+
+  browser.storage.local.set(optionsObj);
+}
+
+async function restoreOptions() {
+  currentOptions = await browser.storage.local.get(DEFAULT_OPTIONS);
+
+  for (let [key, value] of Object.entries(currentOptions)) {
+    document.getElementById(key).value = value;
+  }
+}
+
+function getPermissionFromProfileViewerURL(url) {
+  return url.replace(/:[0-9]+/, '') + '/*';
+}
+
+document.addEventListener('DOMContentLoaded', restoreOptions);
+document.querySelector('form').addEventListener('submit', saveOptions);


### PR DESCRIPTION
Closes #46

This still restricts our permissions to only explicitly specified
URLs, but it should solve all of our needs. Our content script
will only be loaded on pages that match the URL entered into the
UI (there's not much validation on this - there certainly could
be more but I didn't think it was pressing to add it.)