### PR TITLE
Clone objects before assigning them to settings

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,9 @@
 /* global browser */
 
 function adjustState(newState) {
+  // Deep clone the object, since this can be called through popup.html,
+  // which can be unloaded thus leaving this object dead.
+  newState = JSON.parse(JSON.stringify(newState));
   Object.assign(window.profilerState, newState);
   browser.storage.local.set({ profilerState: window.profilerState });
 }


### PR DESCRIPTION
Closes #59

Our settings objects were becoming dead because they were created in popup.js, which is unloaded once you close the popup, thus killing its objects.