### PR TITLE
Use the nightly alias for npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ $ npm install
 $ npm start
 ```
 
-To run other releases of Firefox use the following `npm start` commands.
+The `npm start` command runs [Firefox Nightly](http://nightly.mozilla.org/) by default. To run other releases of Firefox use the following `npm start` commands.
 
-#### Beta Firefox
+#### [Beta Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta)
 
 ```bash
 npm start --geckoprofiler:firefox=beta
 ```
 
-#### Release Firefox
+#### [Release Firefox](https://www.mozilla.org/firefox/)
 
 ```bash
 npm start --geckoprofiler:firefox=firefox

--- a/README.md
+++ b/README.md
@@ -30,8 +30,31 @@ Make sure you have somewhat recent versions of node and npm installed. Then:
 ```bash
 $ git clone https://github.com/devtools-html/Gecko-Profiler-Addon/
 $ cd Gecko-Profiler-Addon/
-$ npm install -g web-ext
-$ web-ext run --firefox=<path-to-firefox>
+$ npm install
+$ npm start
+```
+
+To run other releases of Firefox use the following `npm start` commands.
+
+#### Beta Firefox
+
+```bash
+npm start --geckoprofiler:firefox=beta
+```
+
+#### Release Firefox
+
+```bash
+npm start --geckoprofiler:firefox=firefox
+```
+
+#### Release config
+
+Or you can set the local config to keep the default for the life of your local repository and no longer need to pass the config on the command line.
+
+```bash
+npm config set geckoprofiler:firefox beta
+npm start
 ```
 
 ## Known issues

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "web-ext": "^1.8.1"
   },
   "repository": "https://github.com/devtools-html/Gecko-Profiler-Addon",
+  "config" : { "firefox" : "nightly" },
   "scripts": {
-    "start": "web-ext run",
-    "start-mac-nightly": "web-ext run --firefox=/Applications/FirefoxNightly.app",
+    "start": "web-ext run --firefox=$npm_package_config_firefox",
     "build": "web-ext build -i README.md package.json *.rdf transition resources",
     "prettier": "prettier --single-quote --trailing-comma es5 --write \"./!(node_modules)**/*.js\" *.js",
     "precommit": "lint-staged"


### PR DESCRIPTION
Now you can run `npm start` on Windows or Mac and it will find the
correct binary.

You can also override this value on the command line passing in `npm start --geckoprofiler:firefox=beta` for Beta or `npm start --geckoprofiler:firefox=firefox` for Release.

If you want to change the config value you can run `npm config set geckoprofiler:firefox beta` and `npm start` will default to beta for the life of your local repo.

I’ll add this all to the README in a followup.