### PR TITLE
Add content scripts to detect when the add-on is installed

### DIFF
--- a/content-home.js
+++ b/content-home.js
@@ -1,3 +1,8 @@
+/**
+ * This file injects a check for if the Gecko Profiler Addon is installed into
+ * perf-html.io. It does not work with the dynamically set URL, e.g. for localhost. This
+ * method is simpler and doesn't really impede local development.
+ */
 const injectScript = document.createElement('script');
 const injectFunction = () => {
   // Let perf.html know that the addon is installed.

--- a/content-home.js
+++ b/content-home.js
@@ -1,0 +1,13 @@
+const injectScript = document.createElement('script');
+const injectFunction = () => {
+  // Let perf.html know that the addon is installed.
+  window.isGeckoProfilerAddonInstalled = true;
+
+  if (window.geckoProfilerAddonInstalled) {
+    // In case the add-on was enabled while perf.html was open, notify it that the add-on
+    // was installed.
+    window.geckoProfilerAddonInstalled();
+  }
+};
+injectScript.innerHTML = `(${injectFunction.toString()})();`;
+document.documentElement.appendChild(injectScript);

--- a/manifest.json
+++ b/manifest.json
@@ -48,5 +48,11 @@
   ],
   "optional_permissions": [
     "<all_urls>"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["https://perf-html.io/"],
+      "js": ["content-home.js"]
+    }
   ]
 }


### PR DESCRIPTION
I opted for the simpler "content_scripts" rather than dynamically injecting it based on the custom URL. This needs to land before the perf.html welcome screens patch.