### PR TITLE
Define browser_style in manifest.json to fix a warning.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,7 @@
     "scripts": ["background.js"]
   },
   "browser_action": {
+    "browser_style": false,
     "default_popup": "popup.html",
     "default_title": "Gecko Profiler",
     "default_icon": "icons/toolbar_off.png"


### PR DESCRIPTION
Manifest parsing currently produces the following warning:

> 1498158115827	addons.webextension.geckoprofiler@mozilla.com	WARN	Please specify whether you want browser_style or not in your browser_action options.

This defines browser_style to false, which is the default per MDN, so no change in behavior. Defining as true causes checkboxes in the profiler UI to no longer appear.