### PR TITLE
Add a profiler feature to not collect URLs for network loads by default

### DIFF
--- a/background.js
+++ b/background.js
@@ -169,6 +169,7 @@ async function restartProfiler() {
       buffersize: 10000000, // 90MB
       interval: 1,
       features: {
+        collecturls: false,
         js: true,
         stackwalk: true,
         responsiveness: true,

--- a/popup.html
+++ b/popup.html
@@ -84,6 +84,7 @@
         <li><label><input type="checkbox" class="seqstyle-checkbox">Sequential Styling</label></li>
         <li><label><input type="checkbox" class="tasktracer-checkbox">Task tracer</label></li>
         <li><label><input type="checkbox" class="trackopts-checkbox">Track JIT Optimizations</label></li>
+        <li><label><input type="checkbox" class="collecturls-checkbox">Collect URLs for Network Loads</label></li>
       </ul>
     </section>
     <p class="settings-apply-button-wrapper"><input type="button" class="settings-apply-button" value="Apply (Restart Profiler)"></p>

--- a/popup.js
+++ b/popup.js
@@ -34,6 +34,7 @@ function renderControls(state) {
     intervalScale.fromValueToFraction(state.interval) * 100;
   document.querySelector('.buffersize-range').value =
     buffersizeScale.fromValueToFraction(state.buffersize) * 100;
+  document.querySelector('.collecturls-checkbox').value = state.collecturls;
   document.querySelector('.stackwalk-checkbox').value = state.stackwalk;
   document.querySelector('.responsiveness-checkbox').value =
     state.responsiveness;
@@ -216,6 +217,7 @@ async function setupFeatureCheckbox(featureName) {
   });
 }
 
+setupFeatureCheckbox('collecturls');
 setupFeatureCheckbox('responsiveness');
 setupFeatureCheckbox('stackwalk');
 setupFeatureCheckbox('js');


### PR DESCRIPTION
This is part of [Bug 1460727](https://bugzilla.mozilla.org/show_bug.cgi?id=1460727)