### PR TITLE
Remove the unused collectnetworkurls feature.

### DIFF
--- a/background.js
+++ b/background.js
@@ -169,7 +169,6 @@ async function restartProfiler() {
       buffersize: 10000000, // 90MB
       interval: 1,
       features: {
-        collectnetworkurls: false,
         js: true,
         stackwalk: true,
         responsiveness: true,

--- a/popup.html
+++ b/popup.html
@@ -84,7 +84,6 @@
         <li><label><input type="checkbox" class="seqstyle-checkbox">Sequential Styling</label></li>
         <li><label><input type="checkbox" class="tasktracer-checkbox">Task tracer</label></li>
         <li><label><input type="checkbox" class="trackopts-checkbox">Track JIT Optimizations</label></li>
-        <li><label><input type="checkbox" class="collectnetworkurls-checkbox">Collect Network URLs for Network Loads</label></li>
       </ul>
     </section>
     <p class="settings-apply-button-wrapper"><input type="button" class="settings-apply-button" value="Apply (Restart Profiler)"></p>

--- a/popup.js
+++ b/popup.js
@@ -34,8 +34,6 @@ function renderControls(state) {
     intervalScale.fromValueToFraction(state.interval) * 100;
   document.querySelector('.buffersize-range').value =
     buffersizeScale.fromValueToFraction(state.buffersize) * 100;
-  document.querySelector('.collectnetworkurls-checkbox').value =
-    state.collectnetworkurls;
   document.querySelector('.stackwalk-checkbox').value = state.stackwalk;
   document.querySelector('.responsiveness-checkbox').value =
     state.responsiveness;
@@ -218,7 +216,6 @@ async function setupFeatureCheckbox(featureName) {
   });
 }
 
-setupFeatureCheckbox('collectnetworkurls');
 setupFeatureCheckbox('responsiveness');
 setupFeatureCheckbox('stackwalk');
 setupFeatureCheckbox('js');


### PR DESCRIPTION
This option was added to not collect the URLs by default but we decided
to do it in perf.html side instead.