### PR TITLE
Use the same settings UI as the devtools perf panel

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -12,7 +12,7 @@ html {
 
 body {
   margin: 0;
-  width: 400px;
+  max-width: 32em;
 }
 
 .status-display {
@@ -371,6 +371,7 @@ kbd {
 .perf-settings-feature-label {
   margin: 8px 0;
   display: flex;
+  flex-wrap: wrap;
 }
 
 .perf-settings-checkbox {
@@ -378,7 +379,8 @@ kbd {
 }
 
 .perf-settings-feature-title {
-  flex: 1;
+  margin-left: 20px;
+  flex: 1 100%;
   line-height: 1.6;
 }
 

--- a/popup.css
+++ b/popup.css
@@ -3,7 +3,7 @@ html {
   font: message-box;
   -moz-user-select: none;
   cursor: default;
-  overflow: hidden;
+  overflow: auto;
 }
 
 * {
@@ -12,7 +12,7 @@ html {
 
 body {
   margin: 0;
-  width: 330px;
+  width: 350px;
 }
 
 .status-display {
@@ -189,7 +189,7 @@ kbd {
 }
 
 .settings {
-  background: #F7F7F7;
+  background: #FFFFFF;
 }
 
 .settings:not(.open) > .settings-content,
@@ -255,20 +255,6 @@ kbd {
   background-color: hsla(0, 90%, 40%, 0.5);
 }
 
-.relevancy-level {
-  height: 100%;
-  margin-right: 1px;
-  background: repeating-linear-gradient(to right, #DDD, #DDD 2px, transparent 0, transparent 3px) top left no-repeat;
-  background-size: 400px 20px;
-}
-
-.relevancy-level-fill {
-  height: 100%;
-  width: 40%;
-  background: repeating-linear-gradient(to right, #333, #333 2px, transparent 0, transparent 3px) top left no-repeat;
-  background-size: 400px 20px;
-}
-
 .settings-content {
   margin: 0;
   padding: 0 10px;
@@ -322,4 +308,95 @@ kbd {
   padding: 10px;
   margin: 0;
   text-align: right;
+}
+
+.perf-settings-row {
+  display: flex;
+  overflow: hidden;
+  line-height: 1.8;
+}
+
+.perf-settings-row.focused {
+  background-color: #0074e8;
+  color: #ffffff;
+}
+
+.perf-settings-text-input {
+  width: 100%;
+  padding: 4px;
+  box-sizing: border-box;
+}
+
+.perf-settings-text-label {
+  flex: 1;
+}
+
+.perf-settings-details-contents {
+  overflow: hidden;
+}
+
+.perf-settings-details-contents-slider {
+  padding: 4px;
+  margin: 0 0 18px;
+  border: #ededf0 1px solid;
+  background-color: #f9f9fa;
+  opacity: 0;
+  transform: translateY(-100px);
+  transition-duration: 250ms;
+  transition-timing-function: cubic-bezier(.07,.95,0,1);
+  transition-property: transform, opacity;
+}
+
+.perf-settings-details {
+  grid-column-start: 1;
+  grid-column-end: 3;
+}
+
+.perf-settings-details[open] .perf-settings-details-contents-slider {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.perf-settings-summary {
+  height: 30px;
+  cursor: default;
+  -moz-user-select: none;
+}
+
+.perf-settings-thread-columns {
+  margin-bottom: 20px;
+  display: flex;
+  line-height: 2;
+}
+
+.perf-settings-thread-column {
+  flex: 1;
+}
+
+.perf-settings-checkbox-label {
+  display: block;
+}
+
+.perf-settings-feature-label {
+  margin: 8px 0;
+  display: flex;
+}
+
+.perf-settings-checkbox {
+  align-self: flex-start;
+}
+
+.perf-settings-feature-title {
+  flex: 1;
+  line-height: 14px;
+}
+
+.perf-settings-feature-name {
+  width: 100px;
+  color: #0060df;
+  line-height: 1.6;
+}
+
+.perf-settings-subtext {
+  font-weight: bold;
 }

--- a/popup.css
+++ b/popup.css
@@ -12,6 +12,14 @@ html {
 
 body {
   margin: 0;
+  /**
+   * We had to use `max-width` instead of `width` here because of a bug on Firefox
+   * that causes a horizontal scrollbar when there is a vertical scrollbar on Linux.
+   * This is not a problem on platforms that have a floating scrollbar that doesn't
+   * take additional space, but on platforms that we don't have floating scrollbar,
+   * it takes some space from the body element and causes horizontal scrollbar to appear.
+   * See: https://bugzilla.mozilla.org/show_bug.cgi?id=1400279
+   */
   max-width: 32em;
 }
 
@@ -385,7 +393,6 @@ kbd {
 }
 
 .perf-settings-feature-name {
-  width: 100px;
   color: #0060df;
   line-height: 1.6;
 }

--- a/popup.css
+++ b/popup.css
@@ -12,7 +12,7 @@ html {
 
 body {
   margin: 0;
-  width: 350px;
+  width: 400px;
 }
 
 .status-display {
@@ -257,7 +257,7 @@ kbd {
 
 .settings-content {
   margin: 0;
-  padding: 0 10px;
+  padding: 0 10px 18px;
   line-height: 22px;
   display: grid;
   grid-template-columns: 7em auto;
@@ -305,9 +305,14 @@ kbd {
 }
 
 .settings-apply-button-wrapper {
-  padding: 10px;
+  padding: 4px 10px;
   margin: 0;
   text-align: right;
+  bottom: 0;
+  right: 0;
+  position: fixed;
+  width: 100%;
+  background: #eee;
 }
 
 .perf-settings-row {
@@ -332,29 +337,15 @@ kbd {
 }
 
 .perf-settings-details-contents {
-  overflow: hidden;
-}
-
-.perf-settings-details-contents-slider {
   padding: 4px;
   margin: 0 0 18px;
   border: #ededf0 1px solid;
   background-color: #f9f9fa;
-  opacity: 0;
-  transform: translateY(-100px);
-  transition-duration: 250ms;
-  transition-timing-function: cubic-bezier(.07,.95,0,1);
-  transition-property: transform, opacity;
 }
 
 .perf-settings-details {
   grid-column-start: 1;
   grid-column-end: 3;
-}
-
-.perf-settings-details[open] .perf-settings-details-contents-slider {
-  opacity: 1;
-  transform: translateY(0);
 }
 
 .perf-settings-summary {
@@ -388,7 +379,7 @@ kbd {
 
 .perf-settings-feature-title {
   flex: 1;
-  line-height: 14px;
+  line-height: 1.6;
 }
 
 .perf-settings-feature-name {

--- a/popup.html
+++ b/popup.html
@@ -51,12 +51,6 @@
         <span class="discrete-level-notch critical inactive"></span>
       </div>
     </dd>
-    <dt>Information:</dt>
-    <dd>
-      <div class="relevancy-level">
-        <div class="relevancy-level-fill"></div>
-      </div>
-    </dd>
   </dl>
 
   <section class="settings">
@@ -72,20 +66,104 @@
         <input type="range" class="range-input buffersize-range" min="0" max="100">
         <span class="range-value buffersize-value">90 MB</span>
       </span>
-      <h1 class="settings-setting-label">Threads:</h1>
-      <input type="text" class="settings-textbox threads-textbox"
-             title="Comma-separated list of case-insensitive substring filters for the thread name"
-             value="GeckoMain,Compositor">
-      <h1 class="settings-setting-label">Features:</h1>
-      <ul class="features-list">
-        <li><label><input type="checkbox" class="stackwalk-checkbox" checked>Stack walk</label></li>
-        <li><label><input type="checkbox" class="responsiveness-checkbox" checked>Responsiveness</label></li>
-        <li><label><input type="checkbox" class="js-checkbox" checked>JavaScript</label></li>
-        <li id="screenshots"><label><input type="checkbox" class="screenshots-checkbox">Screenshot capture</label></li>
-        <li><label><input type="checkbox" class="seqstyle-checkbox">Sequential Styling</label></li>
-        <li><label><input type="checkbox" class="tasktracer-checkbox">Task tracer</label></li>
-        <li><label><input type="checkbox" class="trackopts-checkbox">Track JIT Optimizations</label></li>
-      </ul>
+      <details class="perf-settings-details" open="true">
+        <summary class="perf-settings-summary" id="perf-settings-threads-summary">Threads:</summary>
+        <div class="perf-settings-details-contents">
+          <div class="perf-settings-details-contents-slider">
+            <div class="perf-settings-thread-columns">
+              <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="The main processes for both the parent process, and content processes"><input
+                    class="perf-settings-checkbox" id="perf-settings-thread-checkbox-gecko-main" type="checkbox" value="GeckoMain" />GeckoMain</label><label
+                  class="perf-settings-checkbox-label" title="Composites together different painted elements on the page."><input
+                    class="perf-settings-checkbox" id="perf-settings-thread-checkbox-compositor" type="checkbox" value="Compositor" />Compositor</label><label
+                  class="perf-settings-checkbox-label" title="This handle both web workers and service workers"><input class="perf-settings-checkbox"
+                    id="perf-settings-thread-checkbox-dom-worker" type="checkbox" value="DOM Worker" />DOM Worker</label><label
+                  class="perf-settings-checkbox-label" title="When WebRender is enabled, the thread that executes OpenGL calls"><input
+                    class="perf-settings-checkbox" id="perf-settings-thread-checkbox-renderer" type="checkbox" value="Renderer" />Renderer</label></div>
+              <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="The WebRender RenderBackend thread"><input
+                    class="perf-settings-checkbox" id="perf-settings-thread-checkbox-render-backend" type="checkbox" value="RenderBackend" />RenderBackend</label><label
+                  class="perf-settings-checkbox-label" title="When off-main-thread painting is enabled, the thread on which painting happens"><input
+                    class="perf-settings-checkbox" id="perf-settings-thread-checkbox-paint-worker" type="checkbox" value="PaintWorker" />PaintWorker</label><label
+                  class="perf-settings-checkbox-label" title="Style computation is split into multiple threads"><input class="perf-settings-checkbox"
+                    id="perf-settings-thread-checkbox-style-thread" type="checkbox" value="StyleThread" />StyleThread</label><label
+                  class="perf-settings-checkbox-label" title="The thread where networking code runs any blocking socket calls"><input
+                    class="perf-settings-checkbox" id="perf-settings-thread-checkbox-socket-thread" type="checkbox" value="Socket Thread" />Socket
+                  Thread</label></div>
+              <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="TODO"><input class="perf-settings-checkbox"
+                    id="perf-settings-thread-checkbox-stream-trans" type="checkbox" value="StreamTrans" />StreamTrans</label><label
+                  class="perf-settings-checkbox-label" title="Image decoding threads"><input class="perf-settings-checkbox"
+                    id="perf-settings-thread-checkbox-img-decoder" type="checkbox" value="ImgDecoder" />ImgDecoder</label><label
+                  class="perf-settings-checkbox-label" title="DNS resolution happens on this thread"><input class="perf-settings-checkbox"
+                    id="perf-settings-thread-checkbox-dns-resolver" type="checkbox" value="DNS Resolver" />DNS Resolver</label></div>
+            </div>
+            <div class="perf-settings-row"><label class="perf-settings-text-label" title="These thread names are a comma separated list that is used to enable profiling of the threads in the profiler. The name needs to be only a partial match of the thread name to be included. It is whitespace sensitive.">
+                <div>Add custom threads by name:</div><input class="perf-settings-text-input" id="perf-settings-thread-text"
+                  type="text" value="GeckoMain,Compositor" />
+              </label></div>
+          </div>
+        </div>
+      </details>
+      <details class="perf-settings-details" open="true">
+        <summary class="perf-settings-summary" id="perf-settings-features-summary">Features:</summary>
+        <div class="perf-settings-details-contents">
+          <div class="perf-settings-details-contents-slider">
+            <label class="perf-settings-checkbox-label perf-settings-feature-label"><input
+                class="perf-settings-checkbox" id="perf-settings-feature-checkbox-stackwalk" type="checkbox" value="stackwalk" />
+              <div class="perf-settings-feature-name">Native Stacks</div>
+              <div class="perf-settings-feature-title">Record native stacks (C++ and Rust). This is not available on all
+                platforms.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
+            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+                id="perf-settings-feature-checkbox-js" type="checkbox" value="js" />
+              <div class="perf-settings-feature-name">JavaScript</div>
+              <div class="perf-settings-feature-title">Record JavaScript stack information, and interleave it with native
+                stacks.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
+            </label><label class="perf-settings-checkbox-label perf-settings-feature-label" id="java"><input class="perf-settings-checkbox"
+                id="perf-settings-feature-checkbox-java" type="checkbox" value="java" />
+              <div class="perf-settings-feature-name">Java</div>
+              <div class="perf-settings-feature-title">Profile Java code.</div>
+            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+                id="perf-settings-feature-checkbox-responsiveness" type="checkbox" value="responsiveness" />
+              <div class="perf-settings-feature-name">Responsiveness</div>
+              <div class="perf-settings-feature-title">Collect thread responsiveness information.<span class="perf-settings-subtext">
+                  (Recommended on by default.)</span></div>
+            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+                id="perf-settings-feature-checkbox-leaf" type="checkbox" value="leaf" />
+              <div class="perf-settings-feature-name">Native Leaf Stack</div>
+              <div class="perf-settings-feature-title">Record the native memory address of the leaf-most stack. This could be
+                useful on platforms that do not support stack walking.<span class="perf-settings-subtext"> (Recommended on by
+                  default.)</span></div>
+            </label><label class="perf-settings-checkbox-label perf-settings-feature-label" id="screenshots"><input class="perf-settings-checkbox"
+                id="perf-settings-feature-checkbox-screenshots" type="checkbox" value="screenshots" />
+              <div class="perf-settings-feature-name">Screenshots</div>
+              <div class="perf-settings-feature-title">Capture screenshots of browser windows.</div>
+            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+                id="perf-settings-feature-checkbox-mainthreadio" type="checkbox" value="mainthreadio" />
+              <div class="perf-settings-feature-name">Main Thread IO</div>
+              <div class="perf-settings-feature-title">Record main thread I/O markers.</div>
+            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+                id="perf-settings-feature-checkbox-memory" type="checkbox" value="memory" />
+              <div class="perf-settings-feature-name">Memory</div>
+              <div class="perf-settings-feature-title">Add memory measurements to the samples, this includes resident set
+                size (RSS) and unique set size (USS).</div>
+            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+                id="perf-settings-feature-checkbox-privacy" type="checkbox" value="privacy" />
+              <div class="perf-settings-feature-name">Privacy</div>
+              <div class="perf-settings-feature-title">Remove some potentially user-identifiable information.</div>
+            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+                id="perf-settings-feature-checkbox-seqstyle" type="checkbox" value="seqstyle" />
+              <div class="perf-settings-feature-name">Sequential Styling</div>
+              <div class="perf-settings-feature-title">Disable parallel traversal in styling.</div>
+            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+                id="perf-settings-feature-checkbox-trackopts" type="checkbox" value="trackopts" />
+              <div class="perf-settings-feature-name">JIT Optimizations</div>
+              <div class="perf-settings-feature-title">Track JIT optimizations in the JS engine.</div>
+            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+                id="perf-settings-feature-checkbox-tasktracer" type="checkbox" value="tasktracer" />
+              <div class="perf-settings-feature-name">TaskTracer</div>
+              <div class="perf-settings-feature-title">Enable TaskTracer (Experimental, requires custom build.)</div>
+            </label>
+          </div>
+        </div>
+      </details>
     </section>
     <p class="settings-apply-button-wrapper"><input type="button" class="settings-apply-button" value="Apply (Restart Profiler)"></p>
   </section>

--- a/popup.html
+++ b/popup.html
@@ -66,10 +66,9 @@
         <input type="range" class="range-input buffersize-range" min="0" max="100">
         <span class="range-value buffersize-value">90 MB</span>
       </span>
-      <details class="perf-settings-details" open="true">
+      <div class="perf-settings-details">
         <summary class="perf-settings-summary" id="perf-settings-threads-summary">Threads:</summary>
         <div class="perf-settings-details-contents">
-          <div class="perf-settings-details-contents-slider">
             <div class="perf-settings-thread-columns">
               <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="The main processes for both the parent process, and content processes"><input
                     class="perf-settings-checkbox" id="perf-settings-thread-checkbox-gecko-main" type="checkbox" value="GeckoMain" />GeckoMain</label><label
@@ -99,73 +98,70 @@
                 <div>Add custom threads by name:</div><input class="perf-settings-text-input" id="perf-settings-thread-text"
                   type="text" value="GeckoMain,Compositor" />
               </label></div>
-          </div>
         </div>
-      </details>
-      <details class="perf-settings-details" open="true">
+      </div>
+      <div class="perf-settings-details">
         <summary class="perf-settings-summary" id="perf-settings-features-summary">Features:</summary>
         <div class="perf-settings-details-contents">
-          <div class="perf-settings-details-contents-slider">
-            <label class="perf-settings-checkbox-label perf-settings-feature-label"><input
-                class="perf-settings-checkbox" id="perf-settings-feature-checkbox-stackwalk" type="checkbox" value="stackwalk" />
-              <div class="perf-settings-feature-name">Native Stacks</div>
-              <div class="perf-settings-feature-title">Record native stacks (C++ and Rust). This is not available on all
-                platforms.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
-            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-                id="perf-settings-feature-checkbox-js" type="checkbox" value="js" />
-              <div class="perf-settings-feature-name">JavaScript</div>
-              <div class="perf-settings-feature-title">Record JavaScript stack information, and interleave it with native
-                stacks.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
-            </label><label class="perf-settings-checkbox-label perf-settings-feature-label" id="java"><input class="perf-settings-checkbox"
-                id="perf-settings-feature-checkbox-java" type="checkbox" value="java" />
-              <div class="perf-settings-feature-name">Java</div>
-              <div class="perf-settings-feature-title">Profile Java code.</div>
-            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-                id="perf-settings-feature-checkbox-responsiveness" type="checkbox" value="responsiveness" />
-              <div class="perf-settings-feature-name">Responsiveness</div>
-              <div class="perf-settings-feature-title">Collect thread responsiveness information.<span class="perf-settings-subtext">
-                  (Recommended on by default.)</span></div>
-            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-                id="perf-settings-feature-checkbox-leaf" type="checkbox" value="leaf" />
-              <div class="perf-settings-feature-name">Native Leaf Stack</div>
-              <div class="perf-settings-feature-title">Record the native memory address of the leaf-most stack. This could be
-                useful on platforms that do not support stack walking.<span class="perf-settings-subtext"> (Recommended on by
-                  default.)</span></div>
-            </label><label class="perf-settings-checkbox-label perf-settings-feature-label" id="screenshots"><input class="perf-settings-checkbox"
-                id="perf-settings-feature-checkbox-screenshots" type="checkbox" value="screenshots" />
-              <div class="perf-settings-feature-name">Screenshots</div>
-              <div class="perf-settings-feature-title">Capture screenshots of browser windows.</div>
-            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-                id="perf-settings-feature-checkbox-mainthreadio" type="checkbox" value="mainthreadio" />
-              <div class="perf-settings-feature-name">Main Thread IO</div>
-              <div class="perf-settings-feature-title">Record main thread I/O markers.</div>
-            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-                id="perf-settings-feature-checkbox-memory" type="checkbox" value="memory" />
-              <div class="perf-settings-feature-name">Memory</div>
-              <div class="perf-settings-feature-title">Add memory measurements to the samples, this includes resident set
-                size (RSS) and unique set size (USS).</div>
-            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-                id="perf-settings-feature-checkbox-privacy" type="checkbox" value="privacy" />
-              <div class="perf-settings-feature-name">Privacy</div>
-              <div class="perf-settings-feature-title">Remove some potentially user-identifiable information.</div>
-            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-                id="perf-settings-feature-checkbox-seqstyle" type="checkbox" value="seqstyle" />
-              <div class="perf-settings-feature-name">Sequential Styling</div>
-              <div class="perf-settings-feature-title">Disable parallel traversal in styling.</div>
-            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-                id="perf-settings-feature-checkbox-trackopts" type="checkbox" value="trackopts" />
-              <div class="perf-settings-feature-name">JIT Optimizations</div>
-              <div class="perf-settings-feature-title">Track JIT optimizations in the JS engine.</div>
-            </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-                id="perf-settings-feature-checkbox-tasktracer" type="checkbox" value="tasktracer" />
-              <div class="perf-settings-feature-name">TaskTracer</div>
-              <div class="perf-settings-feature-title">Enable TaskTracer (Experimental, requires custom build.)</div>
-            </label>
-          </div>
+          <label class="perf-settings-checkbox-label perf-settings-feature-label"><input
+              class="perf-settings-checkbox" id="perf-settings-feature-checkbox-stackwalk" type="checkbox" value="stackwalk" />
+            <div class="perf-settings-feature-name">Native Stacks</div>
+            <div class="perf-settings-feature-title">Record native stacks (C++ and Rust). This is not available on all
+              platforms.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-js" type="checkbox" value="js" />
+            <div class="perf-settings-feature-name">JavaScript</div>
+            <div class="perf-settings-feature-title">Record JavaScript stack information, and interleave it with native
+              stacks.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label" id="java"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-java" type="checkbox" value="java" />
+            <div class="perf-settings-feature-name">Java</div>
+            <div class="perf-settings-feature-title">Profile Java code.</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-responsiveness" type="checkbox" value="responsiveness" />
+            <div class="perf-settings-feature-name">Responsiveness</div>
+            <div class="perf-settings-feature-title">Collect thread responsiveness information.<span class="perf-settings-subtext">
+                (Recommended on by default.)</span></div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-leaf" type="checkbox" value="leaf" />
+            <div class="perf-settings-feature-name">Native Leaf Stack</div>
+            <div class="perf-settings-feature-title">Record the native memory address of the leaf-most stack. This could be
+              useful on platforms that do not support stack walking.<span class="perf-settings-subtext"> (Recommended on by
+                default.)</span></div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label" id="screenshots"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-screenshots" type="checkbox" value="screenshots" />
+            <div class="perf-settings-feature-name">Screenshots</div>
+            <div class="perf-settings-feature-title">Capture screenshots of browser windows.</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-mainthreadio" type="checkbox" value="mainthreadio" />
+            <div class="perf-settings-feature-name">Main Thread IO</div>
+            <div class="perf-settings-feature-title">Record main thread I/O markers.</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-memory" type="checkbox" value="memory" />
+            <div class="perf-settings-feature-name">Memory</div>
+            <div class="perf-settings-feature-title">Add memory measurements to the samples, this includes resident set
+              size (RSS) and unique set size (USS).</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-privacy" type="checkbox" value="privacy" />
+            <div class="perf-settings-feature-name">Privacy</div>
+            <div class="perf-settings-feature-title">Remove some potentially user-identifiable information.</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-seqstyle" type="checkbox" value="seqstyle" />
+            <div class="perf-settings-feature-name">Sequential Styling</div>
+            <div class="perf-settings-feature-title">Disable parallel traversal in styling.</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-trackopts" type="checkbox" value="trackopts" />
+            <div class="perf-settings-feature-name">JIT Optimizations</div>
+            <div class="perf-settings-feature-title">Track JIT optimizations in the JS engine.</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-tasktracer" type="checkbox" value="tasktracer" />
+            <div class="perf-settings-feature-name">TaskTracer</div>
+            <div class="perf-settings-feature-title">Enable TaskTracer (Experimental, requires custom build.)</div>
+          </label>
         </div>
-      </details>
+      </div>
     </section>
-    <p class="settings-apply-button-wrapper"><input type="button" class="settings-apply-button" value="Apply (Restart Profiler)"></p>
+    <section class="settings-apply-button-wrapper"><input type="button" class="settings-apply-button" value="Apply (Restart Profiler)"></section>
   </section>
 
   <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -272,11 +272,11 @@ function threadTextToList(threads) {
   );
 }
 
-for (let name of features) {
+for (const name of features) {
   setupFeatureCheckbox(name);
 }
 
-for (let name in threadMap) {
+for (const name in threadMap) {
   setupThreadCheckbox(name);
 }
 

--- a/resources/panel-container.html
+++ b/resources/panel-container.html
@@ -21,5 +21,5 @@ iframe {
 <body>
 
 <div id="wrapper">
-  <iframe src="panel-ideas.html" style="width: 350px; height: 330px; border: 0; border-radius: 3.5px; margin: 0; padding: 1px"></iframe>
+  <iframe src="panel-ideas.html" style="width: 400px; height: 930px; border: 0; border-radius: 3.5px; margin: 0; padding: 1px"></iframe>
 </div>

--- a/resources/panel-container.html
+++ b/resources/panel-container.html
@@ -21,5 +21,5 @@ iframe {
 <body>
 
 <div id="wrapper">
-  <iframe src="panel-ideas.html" style="width: 330px; height: 330px; border: 0; border-radius: 3.5px; margin: 0; padding: 1px"></iframe>
+  <iframe src="panel-ideas.html" style="width: 350px; height: 330px; border: 0; border-radius: 3.5px; margin: 0; padding: 1px"></iframe>
 </div>

--- a/resources/panel-ideas.html
+++ b/resources/panel-ideas.html
@@ -193,7 +193,7 @@ kbd {
 }
 
 .settings {
-  background: #F7F7F7;
+  background: #FFFFFF;
 }
 
 .settings:not(.open) > .settings-content,
@@ -259,20 +259,6 @@ kbd {
   background-color: hsla(0, 90%, 40%, 0.5);
 }
 
-.relevancy-level {
-  height: 100%;
-  margin-right: 1px;
-  background: repeating-linear-gradient(to right, #DDD, #DDD 2px, transparent 0, transparent 3px) top left no-repeat;
-  background-size: 400px 20px;
-}
-
-.relevancy-level-fill {
-  height: 100%;
-  width: 40%;
-  background: repeating-linear-gradient(to right, #333, #333 2px, transparent 0, transparent 3px) top left no-repeat;
-  background-size: 400px 20px;
-}
-
 .settings-content {
   margin: 0;
   padding: 0 10px;
@@ -328,6 +314,97 @@ kbd {
   text-align: right;
 }
 
+.perf-settings-row {
+  display: flex;
+  overflow: hidden;
+  line-height: 1.8;
+}
+
+.perf-settings-row.focused {
+  background-color: #0074e8;
+  color: #ffffff;
+}
+
+.perf-settings-text-input {
+  width: 100%;
+  padding: 4px;
+  box-sizing: border-box;
+}
+
+.perf-settings-text-label {
+  flex: 1;
+}
+
+.perf-settings-details-contents {
+  overflow: hidden;
+}
+
+.perf-settings-details-contents-slider {
+  padding: 4px;
+  margin: 0 0 18px;
+  border: #ededf0 1px solid;
+  background-color: #f9f9fa;
+  opacity: 0;
+  transform: translateY(-100px);
+  transition-duration: 250ms;
+  transition-timing-function: cubic-bezier(.07,.95,0,1);
+  transition-property: transform, opacity;
+}
+
+.perf-settings-details {
+  grid-column-start: 1;
+  grid-column-end: 3;
+}
+
+.perf-settings-details[open] .perf-settings-details-contents-slider {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.perf-settings-summary {
+  height: 30px;
+  cursor: default;
+  -moz-user-select: none;
+}
+
+.perf-settings-thread-columns {
+  margin-bottom: 20px;
+  display: flex;
+  line-height: 2;
+}
+
+.perf-settings-thread-column {
+  flex: 1;
+}
+
+.perf-settings-checkbox-label {
+  display: block;
+}
+
+.perf-settings-feature-label {
+  margin: 8px 0;
+  display: flex;
+}
+
+.perf-settings-checkbox {
+  align-self: flex-start;
+}
+
+.perf-settings-feature-title {
+  flex: 1;
+  line-height: 14px;
+}
+
+.perf-settings-feature-name {
+  width: 100px;
+  color: #0060df;
+  line-height: 1.6;
+}
+
+.perf-settings-subtext {
+  font-weight: bold;
+}
+
 </style>
 
 <body>
@@ -378,12 +455,6 @@ kbd {
       <span class="discrete-level-notch critical inactive"></span>
     </div>
   </dd>
-  <dt>Information:</dt>
-  <dd>
-    <div class="relevancy-level">
-      <div class="relevancy-level-fill"></div>
-    </div>
-  </dd>
 </dl>
 
 <section class="settings open">
@@ -397,16 +468,105 @@ kbd {
     <h1 class="settings-setting-label">Buffer size:</h1>
     <span class="range-with-value">
       <input type="range" class="range-input">
-      <span class="range-value">9 MB</span>
+      <span class="range-value">90 MB</span>
     </span>
-    <h1 class="settings-setting-label">Threads:</h1>
-    <input type="text" class="settings-textbox" title="Comma-separated list of case-insensitive substring filters for the thread name" value="GeckoMain,Compositor">
-    <h1 class="settings-setting-label">Features:</h1>
-    <ul class="features-list">
-      <li><label><input type="checkbox" checked>Stack walk</label></li>
-      <li><label><input type="checkbox" checked>JavaScript</label></li>
-      <li><label><input type="checkbox">Task tracer</label></li>
-    </ul>
+    <details class="perf-settings-details" open="true">
+      <summary class="perf-settings-summary" id="perf-settings-threads-summary">Threads:</summary>
+      <div class="perf-settings-details-contents">
+        <div class="perf-settings-details-contents-slider">
+          <div class="perf-settings-thread-columns">
+            <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="The main processes for both the parent process, and content processes"><input
+                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-gecko-main" type="checkbox" value="GeckoMain" />GeckoMain</label><label
+                class="perf-settings-checkbox-label" title="Composites together different painted elements on the page."><input
+                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-compositor" type="checkbox" value="Compositor" />Compositor</label><label
+                class="perf-settings-checkbox-label" title="This handle both web workers and service workers"><input class="perf-settings-checkbox"
+                  id="perf-settings-thread-checkbox-dom-worker" type="checkbox" value="DOM Worker" />DOM Worker</label><label
+                class="perf-settings-checkbox-label" title="When WebRender is enabled, the thread that executes OpenGL calls"><input
+                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-renderer" type="checkbox" value="Renderer" />Renderer</label></div>
+            <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="The WebRender RenderBackend thread"><input
+                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-render-backend" type="checkbox" value="RenderBackend" />RenderBackend</label><label
+                class="perf-settings-checkbox-label" title="When off-main-thread painting is enabled, the thread on which painting happens"><input
+                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-paint-worker" type="checkbox" value="PaintWorker" />PaintWorker</label><label
+                class="perf-settings-checkbox-label" title="Style computation is split into multiple threads"><input class="perf-settings-checkbox"
+                  id="perf-settings-thread-checkbox-style-thread" type="checkbox" value="StyleThread" />StyleThread</label><label
+                class="perf-settings-checkbox-label" title="The thread where networking code runs any blocking socket calls"><input
+                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-socket-thread" type="checkbox" value="Socket Thread" />Socket
+                Thread</label></div>
+            <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="TODO"><input class="perf-settings-checkbox"
+                  id="perf-settings-thread-checkbox-stream-trans" type="checkbox" value="StreamTrans" />StreamTrans</label><label
+                class="perf-settings-checkbox-label" title="Image decoding threads"><input class="perf-settings-checkbox"
+                  id="perf-settings-thread-checkbox-img-decoder" type="checkbox" value="ImgDecoder" />ImgDecoder</label><label
+                class="perf-settings-checkbox-label" title="DNS resolution happens on this thread"><input class="perf-settings-checkbox"
+                  id="perf-settings-thread-checkbox-dns-resolver" type="checkbox" value="DNS Resolver" />DNS Resolver</label></div>
+          </div>
+          <div class="perf-settings-row"><label class="perf-settings-text-label" title="These thread names are a comma separated list that is used to enable profiling of the threads in the profiler. The name needs to be only a partial match of the thread name to be included. It is whitespace sensitive.">
+              <div>Add custom threads by name:</div><input class="perf-settings-text-input" id="perf-settings-thread-text"
+                type="text" value="GeckoMain,Compositor" />
+            </label></div>
+        </div>
+      </div>
+    </details>
+    <details class="perf-settings-details" open="true">
+      <summary class="perf-settings-summary" id="perf-settings-features-summary">Features:</summary>
+      <div class="perf-settings-details-contents">
+        <div class="perf-settings-details-contents-slider">
+          <label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox" id="perf-settings-feature-checkbox-stackwalk"
+              type="checkbox" value="stackwalk" />
+            <div class="perf-settings-feature-name">Native Stacks</div>
+            <div class="perf-settings-feature-title">Record native stacks (C++ and Rust). This is not available on all
+              platforms.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-js" type="checkbox" value="js" />
+            <div class="perf-settings-feature-name">JavaScript</div>
+            <div class="perf-settings-feature-title">Record JavaScript stack information, and interleave it with native
+              stacks.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-responsiveness" type="checkbox" value="responsiveness" />
+            <div class="perf-settings-feature-name">Responsiveness</div>
+            <div class="perf-settings-feature-title">Collect thread responsiveness information.<span class="perf-settings-subtext">
+                (Recommended on by default.)</span></div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-java" type="checkbox" value="java" />
+            <div class="perf-settings-feature-name">Java</div>
+            <div class="perf-settings-feature-title">Profile Java code (Android only).</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-leaf" type="checkbox" value="leaf" />
+            <div class="perf-settings-feature-name">Native Leaf Stack</div>
+            <div class="perf-settings-feature-title">Record the native memory address of the leaf-most stack. This could be
+              useful on platforms that do not support stack walking.</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-mainthreadio" type="checkbox" value="mainthreadio" />
+            <div class="perf-settings-feature-name">Main Thread IO</div>
+            <div class="perf-settings-feature-title">Record main thread I/O markers.</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-memory" type="checkbox" value="memory" />
+            <div class="perf-settings-feature-name">Memory</div>
+            <div class="perf-settings-feature-title">Add memory measurements to the samples, this includes resident set
+              size (RSS) and unique set size (USS).</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-privacy" type="checkbox" value="privacy" />
+            <div class="perf-settings-feature-name">Privacy</div>
+            <div class="perf-settings-feature-title">Remove some potentially user-identifiable information.</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-seqstyle" type="checkbox" value="seqstyle" />
+            <div class="perf-settings-feature-name">Sequential Styling</div>
+            <div class="perf-settings-feature-title">Disable parallel traversal in styling.</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-trackopts" type="checkbox" value="trackopts" />
+            <div class="perf-settings-feature-name">JIT Optimizations</div>
+            <div class="perf-settings-feature-title">Track JIT optimizations in the JS engine.</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-tasktracer" type="checkbox" value="tasktracer" />
+            <div class="perf-settings-feature-name">TaskTracer</div>
+            <div class="perf-settings-feature-title">Enable TaskTracer (Experimental, requires custom build.)</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-screenshots" type="checkbox" value="screenshots" />
+            <div class="perf-settings-feature-name">Screenshots</div>
+            <div class="perf-settings-feature-title">Record screenshots of all browser windows.</div>
+          </label>
+        </div>
+      </div>
+    </details>
   </section>
   <p class="settings-apply-button-wrapper"><input type="button" class="settings-apply-button" value="Apply (Restart Profiler)"></p>
 </section>

--- a/resources/panel-ideas.html
+++ b/resources/panel-ideas.html
@@ -261,7 +261,7 @@ kbd {
 
 .settings-content {
   margin: 0;
-  padding: 0 10px;
+  padding: 0 10px 18px;
   line-height: 22px;
   display: grid;
   grid-template-columns: 7em auto;
@@ -312,6 +312,11 @@ kbd {
   padding: 4px 10px;
   margin: 0;
   text-align: right;
+  bottom: 0;
+  right: 0;
+  position: fixed;
+  width: 100%;
+  background: #eee;
 }
 
 .perf-settings-row {
@@ -336,29 +341,15 @@ kbd {
 }
 
 .perf-settings-details-contents {
-  overflow: hidden;
-}
-
-.perf-settings-details-contents-slider {
   padding: 4px;
   margin: 0 0 18px;
   border: #ededf0 1px solid;
   background-color: #f9f9fa;
-  opacity: 0;
-  transform: translateY(-100px);
-  transition-duration: 250ms;
-  transition-timing-function: cubic-bezier(.07,.95,0,1);
-  transition-property: transform, opacity;
 }
 
 .perf-settings-details {
   grid-column-start: 1;
   grid-column-end: 3;
-}
-
-.perf-settings-details[open] .perf-settings-details-contents-slider {
-  opacity: 1;
-  transform: translateY(0);
 }
 
 .perf-settings-summary {
@@ -392,7 +383,7 @@ kbd {
 
 .perf-settings-feature-title {
   flex: 1;
-  line-height: 14px;
+  line-height: 1.6;
 }
 
 .perf-settings-feature-name {
@@ -470,103 +461,99 @@ kbd {
       <input type="range" class="range-input">
       <span class="range-value">90 MB</span>
     </span>
-    <details class="perf-settings-details" open="true">
+    <div class="perf-settings-details">
       <summary class="perf-settings-summary" id="perf-settings-threads-summary">Threads:</summary>
       <div class="perf-settings-details-contents">
-        <div class="perf-settings-details-contents-slider">
-          <div class="perf-settings-thread-columns">
-            <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="The main processes for both the parent process, and content processes"><input
-                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-gecko-main" type="checkbox" value="GeckoMain" />GeckoMain</label><label
-                class="perf-settings-checkbox-label" title="Composites together different painted elements on the page."><input
-                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-compositor" type="checkbox" value="Compositor" />Compositor</label><label
-                class="perf-settings-checkbox-label" title="This handle both web workers and service workers"><input class="perf-settings-checkbox"
-                  id="perf-settings-thread-checkbox-dom-worker" type="checkbox" value="DOM Worker" />DOM Worker</label><label
-                class="perf-settings-checkbox-label" title="When WebRender is enabled, the thread that executes OpenGL calls"><input
-                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-renderer" type="checkbox" value="Renderer" />Renderer</label></div>
-            <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="The WebRender RenderBackend thread"><input
-                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-render-backend" type="checkbox" value="RenderBackend" />RenderBackend</label><label
-                class="perf-settings-checkbox-label" title="When off-main-thread painting is enabled, the thread on which painting happens"><input
-                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-paint-worker" type="checkbox" value="PaintWorker" />PaintWorker</label><label
-                class="perf-settings-checkbox-label" title="Style computation is split into multiple threads"><input class="perf-settings-checkbox"
-                  id="perf-settings-thread-checkbox-style-thread" type="checkbox" value="StyleThread" />StyleThread</label><label
-                class="perf-settings-checkbox-label" title="The thread where networking code runs any blocking socket calls"><input
-                  class="perf-settings-checkbox" id="perf-settings-thread-checkbox-socket-thread" type="checkbox" value="Socket Thread" />Socket
-                Thread</label></div>
-            <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="TODO"><input class="perf-settings-checkbox"
-                  id="perf-settings-thread-checkbox-stream-trans" type="checkbox" value="StreamTrans" />StreamTrans</label><label
-                class="perf-settings-checkbox-label" title="Image decoding threads"><input class="perf-settings-checkbox"
-                  id="perf-settings-thread-checkbox-img-decoder" type="checkbox" value="ImgDecoder" />ImgDecoder</label><label
-                class="perf-settings-checkbox-label" title="DNS resolution happens on this thread"><input class="perf-settings-checkbox"
-                  id="perf-settings-thread-checkbox-dns-resolver" type="checkbox" value="DNS Resolver" />DNS Resolver</label></div>
-          </div>
-          <div class="perf-settings-row"><label class="perf-settings-text-label" title="These thread names are a comma separated list that is used to enable profiling of the threads in the profiler. The name needs to be only a partial match of the thread name to be included. It is whitespace sensitive.">
-              <div>Add custom threads by name:</div><input class="perf-settings-text-input" id="perf-settings-thread-text"
-                type="text" value="GeckoMain,Compositor" />
-            </label></div>
+        <div class="perf-settings-thread-columns">
+          <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="The main processes for both the parent process, and content processes"><input
+                class="perf-settings-checkbox" id="perf-settings-thread-checkbox-gecko-main" type="checkbox" value="GeckoMain" />GeckoMain</label><label
+              class="perf-settings-checkbox-label" title="Composites together different painted elements on the page."><input
+                class="perf-settings-checkbox" id="perf-settings-thread-checkbox-compositor" type="checkbox" value="Compositor" />Compositor</label><label
+              class="perf-settings-checkbox-label" title="This handle both web workers and service workers"><input class="perf-settings-checkbox"
+                id="perf-settings-thread-checkbox-dom-worker" type="checkbox" value="DOM Worker" />DOM Worker</label><label
+              class="perf-settings-checkbox-label" title="When WebRender is enabled, the thread that executes OpenGL calls"><input
+                class="perf-settings-checkbox" id="perf-settings-thread-checkbox-renderer" type="checkbox" value="Renderer" />Renderer</label></div>
+          <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="The WebRender RenderBackend thread"><input
+                class="perf-settings-checkbox" id="perf-settings-thread-checkbox-render-backend" type="checkbox" value="RenderBackend" />RenderBackend</label><label
+              class="perf-settings-checkbox-label" title="When off-main-thread painting is enabled, the thread on which painting happens"><input
+                class="perf-settings-checkbox" id="perf-settings-thread-checkbox-paint-worker" type="checkbox" value="PaintWorker" />PaintWorker</label><label
+              class="perf-settings-checkbox-label" title="Style computation is split into multiple threads"><input class="perf-settings-checkbox"
+                id="perf-settings-thread-checkbox-style-thread" type="checkbox" value="StyleThread" />StyleThread</label><label
+              class="perf-settings-checkbox-label" title="The thread where networking code runs any blocking socket calls"><input
+                class="perf-settings-checkbox" id="perf-settings-thread-checkbox-socket-thread" type="checkbox" value="Socket Thread" />Socket
+              Thread</label></div>
+          <div class="perf-settings-thread-column"><label class="perf-settings-checkbox-label" title="TODO"><input class="perf-settings-checkbox"
+                id="perf-settings-thread-checkbox-stream-trans" type="checkbox" value="StreamTrans" />StreamTrans</label><label
+              class="perf-settings-checkbox-label" title="Image decoding threads"><input class="perf-settings-checkbox"
+                id="perf-settings-thread-checkbox-img-decoder" type="checkbox" value="ImgDecoder" />ImgDecoder</label><label
+              class="perf-settings-checkbox-label" title="DNS resolution happens on this thread"><input class="perf-settings-checkbox"
+                id="perf-settings-thread-checkbox-dns-resolver" type="checkbox" value="DNS Resolver" />DNS Resolver</label></div>
         </div>
+        <div class="perf-settings-row"><label class="perf-settings-text-label" title="These thread names are a comma separated list that is used to enable profiling of the threads in the profiler. The name needs to be only a partial match of the thread name to be included. It is whitespace sensitive.">
+            <div>Add custom threads by name:</div><input class="perf-settings-text-input" id="perf-settings-thread-text"
+              type="text" value="GeckoMain,Compositor" />
+          </label></div>
       </div>
-    </details>
-    <details class="perf-settings-details" open="true">
+    </div>
+    <div class="perf-settings-details" open="true">
       <summary class="perf-settings-summary" id="perf-settings-features-summary">Features:</summary>
       <div class="perf-settings-details-contents">
-        <div class="perf-settings-details-contents-slider">
-          <label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox" id="perf-settings-feature-checkbox-stackwalk"
-              type="checkbox" value="stackwalk" />
-            <div class="perf-settings-feature-name">Native Stacks</div>
-            <div class="perf-settings-feature-title">Record native stacks (C++ and Rust). This is not available on all
-              platforms.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
-          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-              id="perf-settings-feature-checkbox-js" type="checkbox" value="js" />
-            <div class="perf-settings-feature-name">JavaScript</div>
-            <div class="perf-settings-feature-title">Record JavaScript stack information, and interleave it with native
-              stacks.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
-          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-              id="perf-settings-feature-checkbox-responsiveness" type="checkbox" value="responsiveness" />
-            <div class="perf-settings-feature-name">Responsiveness</div>
-            <div class="perf-settings-feature-title">Collect thread responsiveness information.<span class="perf-settings-subtext">
-                (Recommended on by default.)</span></div>
-          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-              id="perf-settings-feature-checkbox-java" type="checkbox" value="java" />
-            <div class="perf-settings-feature-name">Java</div>
-            <div class="perf-settings-feature-title">Profile Java code (Android only).</div>
-          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-              id="perf-settings-feature-checkbox-leaf" type="checkbox" value="leaf" />
-            <div class="perf-settings-feature-name">Native Leaf Stack</div>
-            <div class="perf-settings-feature-title">Record the native memory address of the leaf-most stack. This could be
-              useful on platforms that do not support stack walking.</div>
-          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-              id="perf-settings-feature-checkbox-mainthreadio" type="checkbox" value="mainthreadio" />
-            <div class="perf-settings-feature-name">Main Thread IO</div>
-            <div class="perf-settings-feature-title">Record main thread I/O markers.</div>
-          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-              id="perf-settings-feature-checkbox-memory" type="checkbox" value="memory" />
-            <div class="perf-settings-feature-name">Memory</div>
-            <div class="perf-settings-feature-title">Add memory measurements to the samples, this includes resident set
-              size (RSS) and unique set size (USS).</div>
-          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-              id="perf-settings-feature-checkbox-privacy" type="checkbox" value="privacy" />
-            <div class="perf-settings-feature-name">Privacy</div>
-            <div class="perf-settings-feature-title">Remove some potentially user-identifiable information.</div>
-          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-              id="perf-settings-feature-checkbox-seqstyle" type="checkbox" value="seqstyle" />
-            <div class="perf-settings-feature-name">Sequential Styling</div>
-            <div class="perf-settings-feature-title">Disable parallel traversal in styling.</div>
-          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-              id="perf-settings-feature-checkbox-trackopts" type="checkbox" value="trackopts" />
-            <div class="perf-settings-feature-name">JIT Optimizations</div>
-            <div class="perf-settings-feature-title">Track JIT optimizations in the JS engine.</div>
-          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-              id="perf-settings-feature-checkbox-tasktracer" type="checkbox" value="tasktracer" />
-            <div class="perf-settings-feature-name">TaskTracer</div>
-            <div class="perf-settings-feature-title">Enable TaskTracer (Experimental, requires custom build.)</div>
-          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
-              id="perf-settings-feature-checkbox-screenshots" type="checkbox" value="screenshots" />
-            <div class="perf-settings-feature-name">Screenshots</div>
-            <div class="perf-settings-feature-title">Record screenshots of all browser windows.</div>
-          </label>
-        </div>
+        <label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox" id="perf-settings-feature-checkbox-stackwalk"
+            type="checkbox" value="stackwalk" />
+          <div class="perf-settings-feature-name">Native Stacks</div>
+          <div class="perf-settings-feature-title">Record native stacks (C++ and Rust). This is not available on all
+            platforms.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
+        </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+            id="perf-settings-feature-checkbox-js" type="checkbox" value="js" />
+          <div class="perf-settings-feature-name">JavaScript</div>
+          <div class="perf-settings-feature-title">Record JavaScript stack information, and interleave it with native
+            stacks.<span class="perf-settings-subtext"> (Recommended on by default.)</span></div>
+        </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+            id="perf-settings-feature-checkbox-responsiveness" type="checkbox" value="responsiveness" />
+          <div class="perf-settings-feature-name">Responsiveness</div>
+          <div class="perf-settings-feature-title">Collect thread responsiveness information.<span class="perf-settings-subtext">
+              (Recommended on by default.)</span></div>
+        </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+            id="perf-settings-feature-checkbox-java" type="checkbox" value="java" />
+          <div class="perf-settings-feature-name">Java</div>
+          <div class="perf-settings-feature-title">Profile Java code (Android only).</div>
+        </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+            id="perf-settings-feature-checkbox-leaf" type="checkbox" value="leaf" />
+          <div class="perf-settings-feature-name">Native Leaf Stack</div>
+          <div class="perf-settings-feature-title">Record the native memory address of the leaf-most stack. This could be
+            useful on platforms that do not support stack walking.</div>
+        </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+            id="perf-settings-feature-checkbox-mainthreadio" type="checkbox" value="mainthreadio" />
+          <div class="perf-settings-feature-name">Main Thread IO</div>
+          <div class="perf-settings-feature-title">Record main thread I/O markers.</div>
+        </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+            id="perf-settings-feature-checkbox-memory" type="checkbox" value="memory" />
+          <div class="perf-settings-feature-name">Memory</div>
+          <div class="perf-settings-feature-title">Add memory measurements to the samples, this includes resident set
+            size (RSS) and unique set size (USS).</div>
+        </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+            id="perf-settings-feature-checkbox-privacy" type="checkbox" value="privacy" />
+          <div class="perf-settings-feature-name">Privacy</div>
+          <div class="perf-settings-feature-title">Remove some potentially user-identifiable information.</div>
+        </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+            id="perf-settings-feature-checkbox-seqstyle" type="checkbox" value="seqstyle" />
+          <div class="perf-settings-feature-name">Sequential Styling</div>
+          <div class="perf-settings-feature-title">Disable parallel traversal in styling.</div>
+        </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+            id="perf-settings-feature-checkbox-trackopts" type="checkbox" value="trackopts" />
+          <div class="perf-settings-feature-name">JIT Optimizations</div>
+          <div class="perf-settings-feature-title">Track JIT optimizations in the JS engine.</div>
+        </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+            id="perf-settings-feature-checkbox-tasktracer" type="checkbox" value="tasktracer" />
+          <div class="perf-settings-feature-name">TaskTracer</div>
+          <div class="perf-settings-feature-title">Enable TaskTracer (Experimental, requires custom build.)</div>
+        </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+            id="perf-settings-feature-checkbox-screenshots" type="checkbox" value="screenshots" />
+          <div class="perf-settings-feature-name">Screenshots</div>
+          <div class="perf-settings-feature-title">Record screenshots of all browser windows.</div>
+        </label>
       </div>
-    </details>
+    </div>
   </section>
   <p class="settings-apply-button-wrapper"><input type="button" class="settings-apply-button" value="Apply (Restart Profiler)"></p>
 </section>


### PR DESCRIPTION
This PR copies over the new devtools performance panel settings style to the add-on. I literally copied over the generated markup and tweaked the JS event handling and initialization to match the simpler add-on architecture. I tried to keep things sufficiently generic, so there is handling for the 'java' profiler feature, even though the add-on doesn't currently work on Fennec (#33). 

I also took the liberty to remove the Information widget, which I believe we no longer consider useful. I inlined some colors that were using CSS variables in the devtools panel, since we don't yet support themes in the add-on.