### PR TITLE
Add a window length setting to popup and send it to profiler

### DIFF
--- a/background.js
+++ b/background.js
@@ -128,11 +128,19 @@ async function startProfiler() {
   const threads = settings.threads.split(',');
   const options = {
     bufferSize: settings.buffersize,
-    bufferDuration: settings.bufferduration,
     interval: settings.interval,
     features: getEnabledFeatures(settings.features, threads),
     threads,
   };
+  if (
+    browser.geckoProfiler.supports &&
+    browser.geckoProfiler.supports.WINDOWLENGTH
+  ) {
+    options.windowLength =
+      settings.windowLength !== settings.infiniteWindowLength
+        ? settings.windowLength
+        : 0;
+  }
   await browser.geckoProfiler.start(options);
 }
 
@@ -187,7 +195,7 @@ async function restartProfiler() {
       isRunning: false,
       settingsOpen: false,
       buffersize: 10000000, // 90MB
-      bufferduration: 20, // 20sec
+      windowLength: 20, // 20sec
       interval: 1,
       features,
       threads: 'GeckoMain,Compositor',

--- a/background.js
+++ b/background.js
@@ -128,6 +128,7 @@ async function startProfiler() {
   const threads = settings.threads.split(',');
   const options = {
     bufferSize: settings.buffersize,
+    bufferDuration: settings.bufferduration,
     interval: settings.interval,
     features: getEnabledFeatures(settings.features, threads),
     threads,
@@ -186,6 +187,7 @@ async function restartProfiler() {
       isRunning: false,
       settingsOpen: false,
       buffersize: 10000000, // 90MB
+      bufferduration: 20, // 20sec
       interval: 1,
       features,
       threads: 'GeckoMain,Compositor',

--- a/popup.css
+++ b/popup.css
@@ -268,7 +268,7 @@ kbd {
   padding: 0 10px 18px;
   line-height: 22px;
   display: grid;
-  grid-template-columns: 7em auto;
+  grid-template-columns: 8em auto;
   grid-template-rows: auto;
 }
 

--- a/popup.css
+++ b/popup.css
@@ -283,6 +283,11 @@ kbd {
   flex-flow: row nowrap;
 }
 
+body.no-windowlength .settings-setting-label.windowlength,
+body.no-windowlength .range-with-value.windowlength {
+  display: none;
+}
+
 .range-input {
   margin: 0;
   width: 0;

--- a/popup.html
+++ b/popup.html
@@ -61,15 +61,15 @@
         <input type="range" class="range-input interval-range" min="0" max="100">
         <span class="range-value interval-value">1 ms</span>
       </span>
+      <h1 class="settings-setting-label windowlength">Window length:</h1>
+      <span class="range-with-value windowlength">
+        <input type="range" class="range-input windowlength-range" min="0" max="100">
+        <span class="range-value windowlength-value">20 sec</span>
+      </span>
       <h1 class="settings-setting-label">Buffer size:</h1>
       <span class="range-with-value">
         <input type="range" class="range-input buffersize-range" min="0" max="100">
         <span class="range-value buffersize-value">90 MB</span>
-      </span>
-      <h1 class="settings-setting-label">Buffer duration:</h1>
-      <span class="range-with-value">
-        <input type="range" class="range-input bufferduration-range" min="0" max="100">
-        <span class="range-value bufferduration-value">20 sec</span>
       </span>
       <div class="perf-settings-details">
         <summary class="perf-settings-summary" id="perf-settings-threads-summary">Threads:</summary>

--- a/popup.html
+++ b/popup.html
@@ -66,6 +66,11 @@
         <input type="range" class="range-input buffersize-range" min="0" max="100">
         <span class="range-value buffersize-value">90 MB</span>
       </span>
+      <h1 class="settings-setting-label">Buffer duration:</h1>
+      <span class="range-with-value">
+        <input type="range" class="range-input bufferduration-range" min="0" max="100">
+        <span class="range-value bufferduration-value">20 sec</span>
+      </span>
       <div class="perf-settings-details">
         <summary class="perf-settings-summary" id="perf-settings-threads-summary">Threads:</summary>
         <div class="perf-settings-details-contents">

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,11 @@
 const intervalScale = makeExponentialScale(0.01, 100);
 const buffersizeScale = makeExponentialScale(10000, 100000000);
-const infiniteWindowLength = 200;
+// Window Length accepts a numerical value between 1-N. We also need to put an
+// infinite number at the end of the window length slider. Therefore, the max
+// value pretends like it's infinite in the slider.
+// The maximum value of window length is 300 seconds. For that reason, we are
+// treating 400 as infinity.
+const infiniteWindowLength = 400;
 const windowLengthScale = makeExponentialScale(1, infiniteWindowLength);
 
 const PROFILE_ENTRY_SIZE = 9; // sizeof(double) + sizeof(char), http://searchfox.org/mozilla-central/rev/e8835f52eff29772a57dca7bcc86a9a312a23729/tools/profiler/core/ProfileEntry.h#73
@@ -46,9 +51,8 @@ function renderState(state) {
   document.querySelector('.buffersize-value').textContent = prettyBytes(
     buffersize * PROFILE_ENTRY_SIZE
   );
-  document.querySelector('.windowlength-value').textContent = `${
-    windowLength === infiniteWindowLength ? '∞' : windowLength
-  } sec`;
+  document.querySelector('.windowlength-value').textContent =
+    windowLength === infiniteWindowLength ? `∞` : `${windowLength} sec`;
   const overhead = calculateOverhead(state);
   const overheadDiscreteContainer = document.querySelector('.discrete-level');
   for (let i = 0; i < overheadDiscreteContainer.children.length; i++) {
@@ -218,16 +222,12 @@ document
   });
 
 window.onload = async () => {
-  const windowLengthVisibility =
-    browser.geckoProfiler.supports &&
-    browser.geckoProfiler.supports.WINDOWLENGTH
-      ? 'flex'
-      : 'none';
-  document
-    .querySelectorAll(
-      '.settings-setting-label.windowlength, .range-with-value.windowlength'
-    )
-    .forEach(el => (el.style.display = windowLengthVisibility));
+  if (
+    !browser.geckoProfiler.supports ||
+    !browser.geckoProfiler.supports.WINDOWLENGTH
+  ) {
+    document.body.classList.add('no-windowlength');
+  }
 
   // Letting the background script know how the infiniteWindowLength is represented.
   const background = await getBackground();

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,6 @@
 const intervalScale = makeExponentialScale(0.01, 100);
 const buffersizeScale = makeExponentialScale(10000, 100000000);
+const bufferdurationScale = makeExponentialScale(1, 200);
 
 const PROFILE_ENTRY_SIZE = 9; // sizeof(double) + sizeof(char), http://searchfox.org/mozilla-central/rev/e8835f52eff29772a57dca7bcc86a9a312a23729/tools/profiler/core/ProfileEntry.h#73
 
@@ -36,7 +37,13 @@ const threadMap = {
 };
 
 function renderState(state) {
-  const { isRunning, settingsOpen, interval, buffersize } = state;
+  const {
+    isRunning,
+    settingsOpen,
+    interval,
+    buffersize,
+    bufferduration,
+  } = state;
   document.documentElement.classList.toggle('status-running', isRunning);
   document.documentElement.classList.toggle('status-stopped', !isRunning);
   document.querySelector('.settings').classList.toggle('open', settingsOpen);
@@ -44,6 +51,9 @@ function renderState(state) {
   document.querySelector('.buffersize-value').textContent = prettyBytes(
     buffersize * PROFILE_ENTRY_SIZE
   );
+  document.querySelector(
+    '.bufferduration-value'
+  ).textContent = `${bufferduration} sec`;
   const overhead = calculateOverhead(state);
   const overheadDiscreteContainer = document.querySelector('.discrete-level');
   for (let i = 0; i < overheadDiscreteContainer.children.length; i++) {
@@ -63,6 +73,8 @@ function renderControls(state) {
     intervalScale.fromValueToFraction(state.interval) * 100;
   document.querySelector('.buffersize-range').value =
     buffersizeScale.fromValueToFraction(state.buffersize) * 100;
+  document.querySelector('.bufferduration-range').value =
+    bufferdurationScale.fromValueToFraction(state.bufferduration) * 100;
 
   for (let name of features) {
     document.getElementById(featurePrefix + name).value = state[name];
@@ -195,6 +207,17 @@ document
     const frac = e.target.value / 100;
     background.adjustState({
       buffersize: buffersizeScale.fromFractionToSingleDigitValue(frac),
+    });
+    renderState(background.profilerState);
+  });
+
+document
+  .querySelector('.bufferduration-range')
+  .addEventListener('input', async e => {
+    const background = await getBackground();
+    const frac = e.target.value / 100;
+    background.adjustState({
+      bufferduration: bufferdurationScale.fromFractionToSingleDigitValue(frac),
     });
     renderState(background.profilerState);
   });

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 const intervalScale = makeExponentialScale(0.01, 100);
 const buffersizeScale = makeExponentialScale(10000, 100000000);
-const bufferdurationScale = makeExponentialScale(1, 200);
+const infiniteWindowLength = 200;
+const windowLengthScale = makeExponentialScale(1, infiniteWindowLength);
 
 const PROFILE_ENTRY_SIZE = 9; // sizeof(double) + sizeof(char), http://searchfox.org/mozilla-central/rev/e8835f52eff29772a57dca7bcc86a9a312a23729/tools/profiler/core/ProfileEntry.h#73
 
@@ -37,13 +38,7 @@ const threadMap = {
 };
 
 function renderState(state) {
-  const {
-    isRunning,
-    settingsOpen,
-    interval,
-    buffersize,
-    bufferduration,
-  } = state;
+  const { isRunning, settingsOpen, interval, buffersize, windowLength } = state;
   document.documentElement.classList.toggle('status-running', isRunning);
   document.documentElement.classList.toggle('status-stopped', !isRunning);
   document.querySelector('.settings').classList.toggle('open', settingsOpen);
@@ -51,9 +46,9 @@ function renderState(state) {
   document.querySelector('.buffersize-value').textContent = prettyBytes(
     buffersize * PROFILE_ENTRY_SIZE
   );
-  document.querySelector(
-    '.bufferduration-value'
-  ).textContent = `${bufferduration} sec`;
+  document.querySelector('.windowlength-value').textContent = `${
+    windowLength === infiniteWindowLength ? '∞' : windowLength
+  } sec`;
   const overhead = calculateOverhead(state);
   const overheadDiscreteContainer = document.querySelector('.discrete-level');
   for (let i = 0; i < overheadDiscreteContainer.children.length; i++) {
@@ -73,8 +68,8 @@ function renderControls(state) {
     intervalScale.fromValueToFraction(state.interval) * 100;
   document.querySelector('.buffersize-range').value =
     buffersizeScale.fromValueToFraction(state.buffersize) * 100;
-  document.querySelector('.bufferduration-range').value =
-    bufferdurationScale.fromValueToFraction(state.bufferduration) * 100;
+  document.querySelector('.windowlength-range').value =
+    windowLengthScale.fromValueToFraction(state.windowLength) * 100;
 
   for (let name of features) {
     document.getElementById(featurePrefix + name).value = state[name];
@@ -212,15 +207,34 @@ document
   });
 
 document
-  .querySelector('.bufferduration-range')
+  .querySelector('.windowlength-range')
   .addEventListener('input', async e => {
     const background = await getBackground();
     const frac = e.target.value / 100;
     background.adjustState({
-      bufferduration: bufferdurationScale.fromFractionToSingleDigitValue(frac),
+      windowLength: windowLengthScale.fromFractionToSingleDigitValue(frac),
     });
     renderState(background.profilerState);
   });
+
+window.onload = async () => {
+  const windowLengthVisibility =
+    browser.geckoProfiler.supports &&
+    browser.geckoProfiler.supports.WINDOWLENGTH
+      ? 'flex'
+      : 'none';
+  document
+    .querySelectorAll(
+      '.settings-setting-label.windowlength, .range-with-value.windowlength'
+    )
+    .forEach(el => (el.style.display = windowLengthVisibility));
+
+  // Letting the background script know how the infiniteWindowLength is represented.
+  const background = await getBackground();
+  background.adjustState({
+    infiniteWindowLength: infiniteWindowLength,
+  });
+};
 
 /**
  * This helper initializes and adds listeners to the features checkboxes that


### PR DESCRIPTION
We are changing the profiler API and adding a field named `bufferDuration` to start parameters. See [Bug 1476775](https://bugzilla.mozilla.org/show_bug.cgi?id=1476775). After the mozilla-central side lands, we have to land this part and package the add-on.

This is pretty much same with the new performance tab part of mozilla-central side patch. Adding the same reviewers. (https://phabricator.services.mozilla.com/D6268)