### PR TITLE
Add JSTracer feature to the gecko profiler addon

### DIFF
--- a/background.js
+++ b/background.js
@@ -168,6 +168,7 @@ async function restartProfiler() {
       stackwalk: true,
       tasktracer: false,
       trackopts: false,
+      jstracer: false,
     };
 
     const platform = await browser.runtime.getPlatformInfo();

--- a/popup.html
+++ b/popup.html
@@ -157,6 +157,10 @@
               id="perf-settings-feature-checkbox-tasktracer" type="checkbox" value="tasktracer" />
             <div class="perf-settings-feature-name">TaskTracer</div>
             <div class="perf-settings-feature-title">Enable TaskTracer (Experimental, requires custom build.)</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-jstracer" type="checkbox" value="jstracer" />
+            <div class="perf-settings-feature-name">JSTracer</div>
+            <div class="perf-settings-feature-title">Trace JS engine (Experimental, requires custom build.)</div>
           </label>
         </div>
       </div>

--- a/popup.js
+++ b/popup.js
@@ -16,6 +16,7 @@ const features = [
   'seqstyle',
   'stackwalk',
   'tasktracer',
+  'jstracer',
   'trackopts',
 ];
 const threadPrefix = 'perf-settings-thread-checkbox-';
@@ -128,6 +129,7 @@ function calculateOverhead(state) {
   const overheadFromJavaScrpt = state.js ? 0.05 : 0;
   const overheadFromSeqStyle = state.seqstyle ? 0.05 : 0;
   const overheadFromTaskTracer = state.tasktracer ? 0.05 : 0;
+  const overheadFromJSTracer = state.jstracer ? 0.05 : 0;
   return clamp(
     overheadFromSampling +
       overheadFromBuffersize +
@@ -135,7 +137,8 @@ function calculateOverhead(state) {
       overheadFromResponsiveness +
       overheadFromJavaScrpt +
       overheadFromSeqStyle +
-      overheadFromTaskTracer,
+      overheadFromTaskTracer +
+      overheadFromJSTracer,
     0,
     1
   );


### PR DESCRIPTION
The JSTracer will be available when the work in https://github.com/devtools-html/perf.html/pull/1422 lands, along with the work in the dependencies for the meta bug here: https://bugzilla.mozilla.org/show_bug.cgi?id=1501377.    This change toggles the JSTracer whenever someone builds firefox using the "--enable-trace-logging" option.  
