### PR TITLE
Show screenshot checkbox on linux as well as macOS

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -205,9 +205,8 @@ document
  */
 async function setupFeatureCheckbox(name) {
   const platform = await browser.runtime.getPlatformInfo();
-  // Screenshots are currently only working on mac.
   if (name == 'screenshots') {
-    if (platform.os !== 'mac') {
+    if (platform.os !== 'mac' && platform.os !== 'linux') {
       document.querySelector('#screenshots').style.display = 'none';
       return;
     }


### PR DESCRIPTION
The OpenGL compositor on Linux supports grabbing screenshots, so this
patch just enables the checkbox to capture screenshots when on Linux. If
the user is using the basic compositor, screenshots will not yet be
captured.