### PR TITLE
Add "profiler.firefox.com" to content_scripts and permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -55,14 +55,18 @@
     "geckoProfiler",
     "webNavigation",
     "storage",
-    "https://perf-html.io/*"
+    "https://perf-html.io/*",
+    "https://profiler.firefox.com/*"
   ],
   "optional_permissions": [
     "<all_urls>"
   ],
   "content_scripts": [
     {
-      "matches": ["https://perf-html.io/"],
+      "matches": [
+        "https://perf-html.io/",
+        "https://profiler.firefox.com/"
+      ],
       "js": ["content-home.js"]
     }
   ]


### PR DESCRIPTION
We are migrating from perf-html.io from `profiler.firefox.com`. Without
that part, profiler.firefox.com doesn't detect that we have gecko
profiler addon installed so it can change its home page.