### PR TITLE
Add profiler state to browser action's title.

### DIFF
--- a/background.js
+++ b/background.js
@@ -215,6 +215,10 @@ async function restartProfiler() {
       path: isRunning ? 'icons/toolbar_on.png' : null,
     });
 
+    browser.browserAction.setTitle({
+      title: isRunning ? 'Gecko Profiler (on)' : null,
+    });
+
     for (const popup of browser.extension.getViews({ type: 'popup' })) {
       popup.renderState(window.profilerState);
     }

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   "browser_action": {
     "browser_style": false,
     "default_popup": "popup.html",
-    "default_title": "Gecko Profiler",
+    "default_title": "Gecko Profiler (off)",
     "default_icon": "icons/toolbar_off.png",
     "theme_icons": [
       {


### PR DESCRIPTION
This allows screen reader users to know the current state of the profiler. Also useful for color blind users, at least until there is a non-color dependent icon.