### PR TITLE
Change devtools-html to firefox-devtools after org renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ That means that you can leave the profiler running, and collect a snapshot of th
 You can control the profiler with two keyboard shortcuts:
 
  - <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>1</kbd>: Stop / Restart profiling
- - <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>2</kbd>: Capture the profile. This captures the current contents of the profiler buffer, opens a tab with perf-html at `https://profiler.firefox.com/`, and sends the profile to it.
+ - <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>2</kbd>: Capture the profile. This captures the current contents of the profiler buffer, opens a tab with Firefox Profiler at `https://profiler.firefox.com/`, and sends the profile to it.
 
-If you want to run your own perf-html instance or want profiles to be sent to a different site that you're developing, you can change the “Reporter URL” preference of this add-on on `about:addons`.
+If you want to run your own Firefox Profiler instance or want profiles to be sent to a different site that you're developing, you can change the “Reporter URL” preference of this add-on on `about:addons`.
 
 ## Development
 
 Make sure you have somewhat recent versions of node and yarn installed. Then:
 
 ```bash
-$ git clone https://github.com/devtools-html/Gecko-Profiler-Addon/
+$ git clone https://github.com/firefox-devtools/Gecko-Profiler-Addon/
 $ cd Gecko-Profiler-Addon/
 $ yarn install
 $ yarn start
@@ -64,12 +64,12 @@ Packaging a new version works like this:
     with the commit message `Release <new version number>.`.
  7. Create a PR and merge.
 
-Landing these changes in the `https://github.com/devtools-html/Gecko-Profiler-Addon/`
+Landing these changes in the `https://github.com/firefox-devtools/Gecko-Profiler-Addon/`
 repository will automatically cause existing installations of the add-on to update
 to the new version. This works because we specify the following URL as the
 `update_url` in `manifest.json`:
-`https://raw.githubusercontent.com/devtools-html/Gecko-Profiler-Addon/master/updates.json`. And that file contains the following "update link" URL:
-`https://raw.githubusercontent.com/devtools-html/Gecko-Profiler-Addon/master/gecko_profiler.xpi`
+`https://raw.githubusercontent.com/firefox-devtools/Gecko-Profiler-Addon/master/updates.json`. And that file contains the following "update link" URL:
+`https://raw.githubusercontent.com/firefox-devtools/Gecko-Profiler-Addon/master/gecko_profiler.xpi`
 This URL always points at the most recent `gecko_profiler.xpi` in the repository.
 
 ## Known issues

--- a/content-home.js
+++ b/content-home.js
@@ -5,11 +5,11 @@
  */
 const injectScript = document.createElement('script');
 const injectFunction = () => {
-  // Let perf.html know that the addon is installed.
+  // Let Firefox Profiler know that the addon is installed.
   window.isGeckoProfilerAddonInstalled = true;
 
   if (window.geckoProfilerAddonInstalled) {
-    // In case the add-on was enabled while perf.html was open, notify it that the add-on
+    // In case the add-on was enabled while Firefox Profiler was open, notify it that the add-on
     // was installed.
     window.geckoProfilerAddonInstalled();
   }

--- a/gecko_profiler.update.rdf
+++ b/gecko_profiler.update.rdf
@@ -12,7 +12,7 @@
                               <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
                               <em:minVersion>38.0a1</em:minVersion>
                               <em:maxVersion>54.*</em:maxVersion>
-                              <em:updateLink>https://raw.githubusercontent.com/devtools-html/Gecko-Profiler-Addon/master/gecko_profiler_legacy.xpi</em:updateLink>
+                              <em:updateLink>https://raw.githubusercontent.com/firefox-devtools/Gecko-Profiler-Addon/master/gecko_profiler_legacy.xpi</em:updateLink>
                             </Description>
                           </em:targetApplication>
                     </Description>
@@ -26,7 +26,7 @@
                               <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
                               <em:minVersion>55.0a1</em:minVersion>
                               <em:maxVersion>*</em:maxVersion>
-                              <em:updateLink>https://raw.githubusercontent.com/devtools-html/Gecko-Profiler-Addon/master/gecko_profiler_transition.xpi</em:updateLink>
+                              <em:updateLink>https://raw.githubusercontent.com/firefox-devtools/Gecko-Profiler-Addon/master/gecko_profiler_transition.xpi</em:updateLink>
                             </Description>
                           </em:targetApplication>
                     </Description>

--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,7 @@
     "gecko": {
       "id": "geckoprofiler@mozilla.com",
       "strict_min_version": "55.0a1",
-      "update_url": "https://raw.githubusercontent.com/devtools-html/Gecko-Profiler-Addon/master/updates.json"
+      "update_url": "https://raw.githubusercontent.com/firefox-devtools/Gecko-Profiler-Addon/master/updates.json"
     }
   },
   "commands": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "shx": "^0.2.2",
     "web-ext": "^2.6.0"
   },
-  "repository": "https://github.com/devtools-html/Gecko-Profiler-Addon",
+  "repository": "https://github.com/firefox-devtools/Gecko-Profiler-Addon",
   "config": {
     "firefox": "nightly"
   },

--- a/transition/bootstrap.js
+++ b/transition/bootstrap.js
@@ -8,7 +8,7 @@ const { utils: Cu } = Components;
 Cu.import('resource://gre/modules/AddonManager.jsm');
 
 const NEW_ADDON_XPI_URL =
-  'https://raw.githubusercontent.com/devtools-html/Gecko-Profiler-Addon/master/gecko_profiler.xpi';
+  'https://raw.githubusercontent.com/firefox-devtools/Gecko-Profiler-Addon/master/gecko_profiler.xpi';
 const ADDON_ID = 'jid0-edalmuivkozlouyij0lpdx548bc@jetpack';
 
 const installListener = {

--- a/transition/install.rdf
+++ b/transition/install.rdf
@@ -9,7 +9,7 @@
         <em:name>Gecko Profiler</em:name>
         <em:description>Collect platform profiles from Firefox Desktop.</em:description>
         <em:creator>Markus Stange &lt;mstange@themasta.com&gt;</em:creator>
-        <em:updateURL>https://raw.githubusercontent.com/devtools-html/Gecko-Profiler-Addon/master/gecko_profiler.update.rdf</em:updateURL>
+        <em:updateURL>https://raw.githubusercontent.com/firefox-devtools/Gecko-Profiler-Addon/master/gecko_profiler.update.rdf</em:updateURL>
         <em:multiprocessCompatible>true</em:multiprocessCompatible>
 
         <em:targetApplication>

--- a/updates.json
+++ b/updates.json
@@ -2,7 +2,7 @@
   "addons": {
     "geckoprofiler@mozilla.com": {
       "updates": [
-        { "version": "0.29", "update_link": "https://raw.githubusercontent.com/devtools-html/Gecko-Profiler-Addon/master/gecko_profiler.xpi" }
+        { "version": "0.29", "update_link": "https://raw.githubusercontent.com/firefox-devtools/Gecko-Profiler-Addon/master/gecko_profiler.xpi" }
       ]
     }
   }


### PR DESCRIPTION
I also changed the places inside transition folder but I think that's okay. Thankfully, github does the redirects for us and we don't need to worry about the previous update links.