### PR TITLE
Add configuration option for marking preference reads

### DIFF
--- a/background.js
+++ b/background.js
@@ -200,6 +200,7 @@ async function restartProfiler() {
       tasktracer: false,
       trackopts: false,
       jstracer: false,
+      preferencereads: false,
     };
 
     const platform = await browser.runtime.getPlatformInfo();

--- a/popup.html
+++ b/popup.html
@@ -166,7 +166,12 @@
               id="perf-settings-feature-checkbox-jstracer" type="checkbox" value="jstracer" />
             <div class="perf-settings-feature-name">JSTracer</div>
             <div class="perf-settings-feature-title">Trace JS engine (Experimental, requires custom build.)</div>
+          </label><label class="perf-settings-checkbox-label perf-settings-feature-label"><input class="perf-settings-checkbox"
+              id="perf-settings-feature-checkbox-preferencereads" type="checkbox" value="preferencereads" />
+            <div class="perf-settings-feature-name">Preference Reads</div>
+            <div class="perf-settings-feature-title">Mark all preference reads.</div>
           </label>
+
         </div>
       </div>
     </section>

--- a/popup.js
+++ b/popup.js
@@ -24,6 +24,7 @@ const features = [
   'stackwalk',
   'tasktracer',
   'jstracer',
+  'preferencereads',
   'trackopts',
 ];
 const threadPrefix = 'perf-settings-thread-checkbox-';
@@ -52,10 +53,8 @@ function renderState(state) {
   document.querySelector('.buffersize-value').textContent = prettyBytes(
     buffersize * PROFILE_ENTRY_SIZE
   );
-  document.querySelector('.windowlength-value').textContent = windowLength ===
-    infiniteWindowLength
-    ? `∞`
-    : `${windowLength} sec`;
+  document.querySelector('.windowlength-value').textContent =
+    windowLength === infiniteWindowLength ? `∞` : `${windowLength} sec`;
   const overhead = calculateOverhead(state);
   const overheadDiscreteContainer = document.querySelector('.discrete-level');
   for (let i = 0; i < overheadDiscreteContainer.children.length; i++) {


### PR DESCRIPTION
This patch corresponds to work done in the profiler core
and front end to create markers whenever Gecko does a
preference read.

@mstange 